### PR TITLE
Add a narrowArray() function

### DIFF
--- a/src/primitives.spec.ts
+++ b/src/primitives.spec.ts
@@ -103,6 +103,14 @@ export class PrimitivesSpec {
     expect(isNumberArray({})).to.equal(false);
   }
 
+  @test public narrowArray() {
+    const isNumberArray = p.narrowArray<number | string, number>(p.isNumber);
+
+    expect(isNumberArray([10, 20])).to.equal(true);
+    expect(isNumberArray([10, "foo"])).to.equal(false);
+    expect(isNumberArray([])).to.equal(true);
+  }
+
   @test public objectLike() {
     expect(p.isObjectLike({ foo: "bar" })).to.equal(true);
     expect(p.isObjectLike([])).to.equal(true);

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -1,4 +1,4 @@
-import { TypeGuard } from "./guards";
+import { PartialTypeGuard, TypeGuard } from "./guards";
 
 /**
  * Validate if a value is a javascript number.
@@ -78,6 +78,13 @@ export const isMissing = <T>(tgt: TypeGuard<T>): TypeGuard<T | undefined | null>
 export const isArray =
   <T>(valueCheck: TypeGuard<T>): TypeGuard<T[]> => (arr: any): arr is T[] =>
     Array.isArray(arr) && arr.reduce<boolean>((acc, v) => acc && valueCheck(v), true);
+
+/**
+ * Narrow the type of elements inside an array.
+ */
+export const narrowArray =
+  <T, U extends T>(pt: PartialTypeGuard<T, U>): PartialTypeGuard<T[], U[]> =>
+    (ts: T[]): ts is U[] => ts.reduce<boolean>((acc, b) => acc && pt(b), true);
 
 /**
  * Validate if a value is like an object.


### PR DESCRIPTION
Adds a composable way to narrow the type of an array as a `PartialTypeGuard<T[], U[]>`.