### PR TITLE
Add exact option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,28 @@
-version: 2
+version: 2.1
 
-build: &BUILD
-  steps:
-    - checkout
-    - run: npm install
-    - run: npm run build
-    - run: npm test
-    - run: npm run codecov-report
+orbs:
+  node: circleci/node@4.2.0
 
 jobs:
-  dubnium:
-    <<: *BUILD
-    working_directory: ~/gtg
-    docker:
-      - image: circleci/node:10
-  erbium:
-    <<: *BUILD
-    working_directory: ~/gtg
-    docker:
-      - image: circleci/node:12
-  fermium:
-    <<: *BUILD
-    working_directory: ~/gtg
-    docker:
-      - image: circleci/node:14
-  latest:
-    <<: *BUILD
-    working_directory: ~/gtg
-    docker:
-      - image: circleci/node
+  ci:
+    parameters:
+      node-version:
+        type: string
+    executor:
+      name: node/default
+      tag: << parameters.node-version >>
+    working_directory: /mnt/ramdisk
+    steps:
+      - checkout
+      - run: npm install
+      - run: npm run build
+      - run: npm test
+      - run: npm run codecov-report
   stryker:
-    working_directory: ~/gtg
-    docker:
-      - image: circleci/node:14
+    executor:
+      name: node/default
+      tag: '14.16'
+    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - run: npm install
@@ -46,12 +36,13 @@ workflows:
   version: 2
   ci:
     jobs:
-      - dubnium:
-          requires: ['fermium']
-      - erbium:
-          requires: ['fermium']
-      - fermium
-      - latest:
-          requires: ['fermium']
-      - stryker:
-          requires: ['fermium']
+      - ci:
+          name: dubnium
+          node-version: '10.24'
+      - ci:
+          name: erbium
+          node-version: '12.21'
+      - ci:
+          name: fermium
+          node-version: '14.16'
+      - stryker

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "tslint.packageManager": "yarn"
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "stryker": "stryker run",
     "stryker-watch": "nodemon -e ts,json --exec stryker run",
     "codecov-local": "nyc report",
-    "codecov-report": "nyc report --reporter=json && codecov -p ../.. -f coverage/*.json -F generic_type_guard"
+    "codecov-report": "nyc report --reporter=json && codecov -f coverage/*.json -F generic_type_guard"
   },
   "nyc": {
     "include": [

--- a/src/objects.spec.ts
+++ b/src/objects.spec.ts
@@ -138,4 +138,17 @@ describe('Objects', function (this: Mocha.Suite) {
     expect(hasOnlyProps({ foo: 'foo' })).to.equal(false);
     expect(hasOnlyProps({ foo: 'foo', bar: '1' })).to.equal(false);
   });
+
+  describe('#exactObject', () => {
+    it('checks for ', () => {
+      const isObjectWithLength = o.isExactObject({
+        length: p.isNumber,
+      });
+
+      expect(isObjectWithLength({ length: 10 })).to.equal(true);
+      expect(isObjectWithLength({ hello: 'world' })).to.equal(false);
+      // arrays are object type but not objects for isObject
+      expect(isObjectWithLength([])).to.equal(false);
+    });
+  });
 });

--- a/src/objects.spec.ts
+++ b/src/objects.spec.ts
@@ -123,7 +123,19 @@ describe('Objects', function (this: Mocha.Suite) {
   it('properties', () => {
     const hasProps = o.hasProperties({ foo: p.isString, bar: p.isNumber });
     expect(hasProps({ foo: 'foo', bar: 1 })).to.equal(true);
+    expect(hasProps({ foo: 'foo', bar: 1, baz: false })).to.equal(true);
     expect(hasProps({ foo: 'foo' })).to.equal(false);
     expect(hasProps({ foo: 'foo', bar: '1' })).to.equal(false);
+  });
+
+  it('onlyProperties', () => {
+    const hasOnlyProps = o.hasOnlyProperties({
+      foo: p.isString,
+      bar: p.isNumber,
+    });
+    expect(hasOnlyProps({ foo: 'foo', bar: 1 })).to.equal(true);
+    expect(hasOnlyProps({ foo: 'foo', bar: 1, baz: false })).to.equal(false);
+    expect(hasOnlyProps({ foo: 'foo' })).to.equal(false);
+    expect(hasOnlyProps({ foo: 'foo', bar: '1' })).to.equal(false);
   });
 });

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,4 +1,5 @@
 import type { MappedTypeGuard, PartialTypeGuard, TypeGuard } from './guards';
+import { combine } from './utils';
 import { isObject } from './primitives';
 
 /**
@@ -177,3 +178,12 @@ export const hasOptionalProperties = <V extends object>(
 
   return true;
 };
+
+/**
+ * Validate that an object has exactly the fields provided
+ *
+ * @public
+ */
+export const isExactObject = <V extends object>(
+  props: MappedTypeGuard<V>,
+): TypeGuard<V> => combine(isObject, hasProperties(props));

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -132,6 +132,33 @@ export const hasProperties = <V extends object>(
 };
 
 /**
+ * Validate that a given object only has the given properties
+ *
+ * @param props - A MappedTypeGuard of the object to be validated.
+ *
+ * @public
+ */
+export const hasOnlyProperties = <V extends object>(
+  props: MappedTypeGuard<V>,
+): PartialTypeGuard<object, V> => (o: object): o is V => {
+  const found: Array<keyof typeof props> = [];
+
+  for (const prop in o) {
+    if (prop in props) {
+      const propsKey = prop as Extract<keyof typeof props, string>;
+      if (!hasProperty(propsKey, props[propsKey])(o)) {
+        return false;
+      }
+      found.push(propsKey);
+    } else {
+      return false;
+    }
+  }
+
+  return found.length === Object.keys(props).length;
+};
+
+/**
  * Validate that a given object has all the given optional properties
  *
  * @param props - a MappedGuard of the object to be validated, i.e. an object that has the same properties as the

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,7 @@
-import { assert, AssertionError } from './utils';
+import { assert, AssertionError, combine } from './utils';
+import { isNumber, isObject } from './primitives';
 import { expect } from 'chai';
+import { hasProperties } from './objects';
 import td from 'testdouble';
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
@@ -44,6 +46,21 @@ describe('utils', function (this: Mocha.Suite): void {
         RangeError,
         'Hello world',
       );
+    });
+  });
+
+  describe('#combine', () => {
+    it('combines two assertions', () => {
+      const hasLength = hasProperties({
+        length: isNumber,
+      });
+      const isCool = combine(isObject, hasLength);
+
+      expect(isCool({ length: 10 })).to.equal(true);
+      expect(isCool({ hello: 'world' })).to.equal(false);
+      // arrays are object type but not objects for isObject
+      expect(hasLength([])).to.equal(true);
+      expect(isCool([])).to.equal(false);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { GuardedType, PartialTypeGuard } from './guards';
+import type { GuardedType, PartialTypeGuard as PTG } from './guards';
 
 /**
  * Indicates there was an error validating a typeguard.
@@ -22,7 +22,7 @@ export class AssertionError extends RangeError {
  * @throws AssertionError if the guard returns false.
  * @public
  */
-export const assert: <T, Guard extends PartialTypeGuard<T, T>>(
+export const assert: <T, Guard extends PTG<T, T>>(
   value: T,
   guard: Guard,
   message?: string,
@@ -33,4 +33,41 @@ export const assert: <T, Guard extends PartialTypeGuard<T, T>>(
       message ?? `Invalid value provided: ${JSON.stringify(value)}`,
     );
   }
+};
+
+/**
+ * Helper to string many different typeguards together into something larger.
+ *
+ * @param guards A list of partial typeguards to string together.
+ *
+ * @public
+ */
+export const combine: {
+  <A, B extends A, C extends B>(g1: PTG<A, B>, g2: PTG<B, C>): PTG<A, C>;
+  <A, B extends A, C extends B, D extends C>(
+    g1: PTG<A, B>,
+    g2: PTG<B, C>,
+    g3: PTG<C, D>,
+  ): PTG<A, D>;
+  <A, B extends A, C extends B, D extends C, E extends D>(
+    g1: PTG<A, B>,
+    g2: PTG<B, C>,
+    g3: PTG<C, D>,
+    g4: PTG<D, E>,
+  ): PTG<A, E>;
+  <A, B extends A, C extends B, D extends C, E extends D, F extends E>(
+    g1: PTG<A, B>,
+    g2: PTG<B, C>,
+    g3: PTG<C, D>,
+    g4: PTG<D, E>,
+    g5: PTG<D, E>,
+  ): PTG<A, F>;
+} = (...guards: Array<PTG<unknown, unknown>>) => (v: unknown): v is unknown => {
+  for (const guard of guards) {
+    if (!guard(v)) {
+      return false;
+    }
+  }
+
+  return true;
 };


### PR DESCRIPTION
Fixes #34.

Adds:

* `gtg.hasOnlyProperties` - like `hasProperties` but will return a failure if extra properties are detected.
* `gtg.combine` - provides a helper to string together many `PartialTypeGuards` in one call to take full advantage of them, eg. `combine(isObject, hasOnlyProperties({ length: isNumber }))`
* `gtg.exactOptions` - shorthand for a full type guard that checks the value is an object with a precise set of properties.