### PR TITLE
fix: allow isInstance to work with generic classes

### DIFF
--- a/etc/generic-type-guard.api.md
+++ b/etc/generic-type-guard.api.md
@@ -103,7 +103,7 @@ export const isFloat: TypeGuard<number>;
 export const isInfinity: TypeGuard<number>;
 
 // @public
-export const isInstance: <T extends object>(klass: new (...args: never[]) => T) => TypeGuard<T>;
+export const isInstance: <T extends object>(klass: abstract new (...args: never[]) => T) => TypeGuard<T>;
 
 // @public
 export class IsInterface implements InterfaceBuilder<object> {

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -94,7 +94,7 @@ export const hasNumericIndexSignature =
  * @public
  */
 export const isInstance =
-  <T extends object>(klass: new (...args: never[]) => T): TypeGuard<T> =>
+  <T extends object>(klass: abstract new (...args: never[]) => T): TypeGuard<T> =>
   (o: unknown): o is T =>
     o instanceof klass;
 


### PR DESCRIPTION
Allow for isInstance to work with generic classes, eg.

```typescript
class Foo<T = unknown> {}

const isFoo = isInstance(Foo);
```

This won't be a desirable thing to do in some cases, but should be reasonably easy to discover why things aren't working the way you want them to in those cases.